### PR TITLE
Fix page jitter bug

### DIFF
--- a/app/static/main.css
+++ b/app/static/main.css
@@ -10,6 +10,7 @@ html, body {
     height: 100%;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 #header {


### PR DESCRIPTION
The margin of the loader went past the bounds of the page, which caused a scrollbar to appear. Setting `overflow: hidden` fixed it.